### PR TITLE
assignmentCloseDate may not be present

### DIFF
--- a/src/Warwick/Tabula/Coursework.hs
+++ b/src/Warwick/Tabula/Coursework.hs
@@ -76,7 +76,7 @@ data Assignment = Assignment {
     assignmentOpened :: Bool,
     assignmentClosed :: Bool,
     assignmentOpenDate :: TabulaDateTime,
-    assignmentCloseDate :: TabulaDateTime,
+    assignmentCloseDate :: Maybe TabulaDateTime,
     assignmentFeedbackDeadline :: Maybe TabulaDate,
     assignmentFeedback :: Int,
     assignmentUnpublishedFeedback :: Int


### PR DESCRIPTION
Per the [Tabula API documentation](https://warwick.ac.uk/services/its/servicessupport/web/tabula/api/coursework/assignments/assignment-object)